### PR TITLE
chore: add plausible analytics

### DIFF
--- a/src/.vuepress/config/head.js
+++ b/src/.vuepress/config/head.js
@@ -39,4 +39,13 @@ module.exports = [
       src: 'https://proxy.daas.workers.dev/js/script.js',
     },
   ],
+  [
+    'script',
+    {
+      defer: true,
+      'data-domain': "blog.libp2p.io",
+      src: "https://plausible.io/js/plausible.js"
+    },
+    ``
+  ],
 ].concat(favicons)


### PR DESCRIPTION
Adds analytics to the blog site, managed by the DaaS account.

https://plausible.io/blog.libp2p.io/