### PR TITLE
Don't render single newlines as line-breaks

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -72,9 +72,6 @@ module.exports = {
   dest: './dist',
   markdown: {
     extendMarkdown: (md) => {
-      md.set({
-        breaks: true,
-      })
       md.use(require('markdown-it-video'))
       md.use(require('markdown-it-footnote'))
       md.use(require('markdown-it-task-lists'))


### PR DESCRIPTION
When rendering markdown, single newlines are typically ignored and only double newlines are rendered as a new paragraph.

This allows for each sentence to be on a new line without introducing unnecessary line breaks in the rendered document. Keeping each sentence on a new line makes reviews easier and plays well with Git which tracks changes on a line-by-line basis. It also eases collaboration of documents in GitHub's PR process through the "suggestion" feature.

Here are two screenshot comparing the two renderings.

|`breaks: false` (the default)|`breaks: true`|
|---|---|
|![Screenshot from 2023-01-13 14-42-10](https://user-images.githubusercontent.com/5486389/212232178-9ba6e1fb-fa46-4021-855d-3f6215a2b72e.png)|![Screenshot from 2023-01-13 14-42-16](https://user-images.githubusercontent.com/5486389/212232185-6f2ae085-cae2-48e7-bab2-ea8b08fcfe68.png)|

As we can see, the rendering is identical. Changing this setting will allow us to use "one sentence per line" in future posts. It is however not mandatory in case some authors don't want to use it.

I am not sure it is worth to convert existing posts.
