### PR TITLE
feat: add ecosystemcontent category with link to Rust Bootstrapper article

### DIFF
--- a/src/.vuepress/theme/components/blog/Card.vue
+++ b/src/.vuepress/theme/components/blog/Card.vue
@@ -39,6 +39,7 @@ export default {
         case 'News coverage':
         case 'Release notes':
         case 'Tutorial':
+        case 'Ecosystem content':
         case 'Video':
           return LinkCard
 

--- a/src/_blog/ecosystemcontent.md
+++ b/src/_blog/ecosystemcontent.md
@@ -1,0 +1,16 @@
+---
+title: Ecosystem content
+type: Ecosystem content
+sitemap:
+  exclude: true
+data:
+- title: 'A Rusty Bootstrapper'
+  date: 2023-07-24
+  publish_date:
+  card_image: /blog-post-placeholder.png
+  path: https://blog.ipfs.tech/2023-rust-libp2p-based-ipfs-bootstrap-node/
+  tags:
+  - 'Kademlia'
+  - 'Rust'
+  - 'libp2p'
+---


### PR DESCRIPTION
This updates libp2p/blog to include the ecosystem content category similar to https://github.com/ipfs/ipfs-blog/pull/581 (which was created in ipfs/ipfs-blog to cross post libp2p content like https://github.com/ipfs/ipfs-blog/pull/578)