### PR TITLE
docs: add Helia to turnkey list and update module name

### DIFF
--- a/src/_blog/auto-tls.md
+++ b/src/_blog/auto-tls.md
@@ -35,6 +35,7 @@ If you prefer a turn-key implementation:
 
 - [IPFS Kubo](https://docs.ipfs.tech/install/command-line/) >= 0.33: Opt-in via [`AutoTLS.Enabled` configuration flag](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotlsenabled)
 - [IPFS Desktop](https://docs.ipfs.tech/install/ipfs-desktop/) >= 0.41: enabled by default
+- [Helia](http://npmjs.com/package/helia) >= 5.2.0: enabled by default
 
 ## Use-cases for AutoTLS
 
@@ -191,7 +192,7 @@ AutoTLS is an opt-in feature and can be enabled in:
 - [Kubo](https://github.com/ipfs/kubo/releases/tag/v0.33.0) >= 0.33.
 - [IPFS Desktop](https://github.com/ipfs/ipfs-desktop/releases/tag/v0.41.0) >= 0.41.
 - [Helia](https://github.com/ipfs/helia/releases/tag/helia-v5.2.0) >= 5.2.0.
-- [js-libp2p](https://www.npmjs.com/package/@libp2p/auto-tls) for Node.js.
+- [js-libp2p](https://www.npmjs.com/package/@ipshipyard/libp2p-auto-tls) for Node.js.
 - [go-libp2p](https://github.com/ipshipyard/p2p-forge/tree/main/client).
 
 To see code examples of how to use AutoTLS with js-libp2p and go-libp2p, check out the following repositories:


### PR DESCRIPTION
Adds Helia to the list of out-of-the-box implementations and updates the module name the js implementation is published under.