### PR TITLE
fix slack link in js-libp2p v1.0.0 release blog

### DIFF
--- a/src/_blog/js-libp2p-v1.md
+++ b/src/_blog/js-libp2p-v1.md
@@ -133,7 +133,7 @@ If you would like to learn more about libp2p, a great place to start is always t
 
 * [js-libp2p Discussions](https://github.com/libp2p/js-libp2p/discussions)
   * This is a great place to discuss issues, ideas, and enhancements with the community.
-* [Slack - the libp2p-implementers channel](filecoin.io/slack)
+* [Slack - the libp2p-implementers channel](https://filecoinproject.slack.com/archives/C03K82MU486)
   * This is a great place to have real-time discussions with the community.
 * [libp2p Specifications](https://github.com/libp2p/specs/)
   * This describes the various libp2p specifications across implementations.


### PR DESCRIPTION
Fixes: #148

The Slack - the libp2p-implementers channel link in the 
[Announcing the release of js-libp2p v1.0.0 ](https://blog.libp2p.io/2023-12-12-js-libp2p/)blog post currently points 
to a relative path (`filecoin.io/slack`), which results in a 404 error 
when viewed on the blog.

### Before
Clicking the link on the blog redirected to:
https://blog.libp2p.io/2023-12-12-js-libp2p/filecoin.io/slack (404)

### After
Clicking the link will now correctly open the libp2p implementers Slack channel:
https://filecoinproject.slack.com/archives/C03K82MU486

